### PR TITLE
Update layout & time display

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,11 +49,19 @@
                     bus.forEach((times, day) => {
                         if (now.getDay() === day + 1 || busNum === 0) {
                             const nextTime = times.find(t => getDate(t) > now);
+                            
+                            const timeLeft = nextTime ? new Date(getDate(nextTime) - now) : null;
+                            const timeLeftFormatted = timeLeft 
+                                ? `${timeLeft.getMinutes()}:${timeLeft.getSeconds().toString().padStart(2, '0')}`
+                                : null;
+
                             const card = document.createElement('div');
                             card.className = 'card';
                             card.innerHTML = `
                         <h3>Bus ${busNum + 1} ${direction.replace('To', ' → ')}</h3>
-                        <div class="next-bus-box">Next: ${nextTime || 'No next bus today'}</div>
+                        <div class="next-bus-box ${nextTime ? 'next-bus-active' : 'next-bus-inactive'}">
+                            ${nextTime ? `Remaining: ${timeLeftFormatted}` :'No next bus today'}
+                        </div>
                         <div class="time-list">
                             ${times.map(t =>
                                 `<div class="time-item ${getDate(t) < now ?

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 <body>
     <header>
-        <h1>Shuttle Bus Timetable</h1>
+        <h1 class="title">Shuttle Bus Timetable</h1>
     </header>
     <div id="status" class="card"></div>
     <div id="timetable"></div>

--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,10 @@ body {
     border-bottom: 1px solid #eee;
 }
 
+.title {
+    margin-left: 10px;
+}
+
 @media (prefers-color-scheme: dark) {
     body {
         background: #1a1a1a;

--- a/styles.css
+++ b/styles.css
@@ -19,9 +19,16 @@ body {
 
 .next-bus-box {
     color: white;
-    background: var(--secondary);
     padding: 12px 15px;
     border-radius: 8px;
+}
+
+.next-bus-active {
+    background: var(--secondary);
+}
+
+.next-bus-inactive {
+    background: #444444;
 }
 
 .next-bus {


### PR DESCRIPTION
1. Align title with cards by adding 10px left margin.
2. Display the next bus's remaining time instead of the current time since we can easily find the time in the table and conveniently check the remaining time.
3. The next bus's remaining time indicator becomes dark after all buses have gone.